### PR TITLE
fix: repair github link

### DIFF
--- a/src/components/NavBar.astro
+++ b/src/components/NavBar.astro
@@ -22,7 +22,7 @@
     class="i-tabler-brand-unsplash hover:translate-y--3px transition-160"
     title="My Unsplash"></a>
   <a
-    href="https://github/zhangzheheng12345"
+    href="https://github.com/zhangzheheng12345"
     target="_blank"
     class="i-lucide-github hover:translate-y--3px transition-160"
     title="My GitHub"></a>


### PR DESCRIPTION
The `GItHub` link on NavBar is `https://github/*` which is not accessible. I added `.com` after `github` in this pull request.
